### PR TITLE
Volunteering improvements

### DIFF
--- a/apps/volunteer/choose_roles.py
+++ b/apps/volunteer/choose_roles.py
@@ -73,7 +73,7 @@ def choose_role():
 
         db.session.commit()
         flash("Your role list has been updated", 'info')
-        return redirect(url_for('.choose_role'))
+        return redirect(url_for('.schedule'))
 
     current_roles = current_volunteer.interested_roles.all()
     if current_roles:

--- a/apps/volunteer/choose_roles.py
+++ b/apps/volunteer/choose_roles.py
@@ -89,9 +89,10 @@ def choose_role():
 def role(role_id):
     role = Role.query.get_or_404(role_id)
     current_volunteer = VolunteerUser.get_for_user(current_user)
+    signed_up_for_role = current_volunteer.interested_roles.filter_by(id = role_id).first()
 
     if request.method == "POST":
-        if role_id in current_volunteer.interested_roles:
+        if signed_up_for_role:
             current_volunteer.interested_roles.remove(role)
         else:
             current_volunteer.interested_roles.append(role)
@@ -108,5 +109,6 @@ def role(role_id):
         description = None
 
     return render_template('volunteer/role.html', description=description,
-                           role=role, current_volunteer=current_volunteer)
+                           role=role, current_volunteer=current_volunteer,
+                           signed_up_for_role=signed_up_for_role)
 

--- a/apps/volunteer/main.py
+++ b/apps/volunteer/main.py
@@ -2,12 +2,15 @@
 from flask import redirect, url_for, render_template
 
 from . import volunteer
-from ..common import feature_flag
+from ..common import feature_flag, feature_enabled
 
 @volunteer.route('/')
 @feature_flag('VOLUNTEERS_SIGNUP')
 def main():
-    return redirect(url_for('.sign_up'))
+    if feature_enabled("VOLUNTEERS_SCHEDULE"):
+        return redirect(url_for('.schedule'))
+    else:
+        return redirect(url_for('.sign_up'))
 
 @volunteer.route('/safeguarding')
 @feature_flag('VOLUNTEERS_SIGNUP')

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -38,6 +38,9 @@ def _get_interested_roles(user):
 @feature_flag('VOLUNTEERS_SCHEDULE')
 @v_user_required
 def schedule():
+    if not current_user.has_permission('volunteer:user'):
+        return redirect(url_for('.sign-up'))
+
     shifts = Shift.get_all()
     by_time = defaultdict(lambda: defaultdict(list))
 

--- a/templates/volunteer/_nav.html
+++ b/templates/volunteer/_nav.html
@@ -7,7 +7,7 @@
     {% if current_user.is_authenticated %}
     {{ menuitem('Account', '.account') }}
     {{ menuitem('Roles', '.choose_role') }}
-    {% if config.get('VOLUNTEERS_SCHEDULE') %}
+    {% if feature_enabled('VOLUNTEERS_SCHEDULE') %}
     {{ menuitem('Shift sign-up', '.schedule') }}
     {% endif %}
     {% else %}

--- a/templates/volunteer/_schedule_filters.html
+++ b/templates/volunteer/_schedule_filters.html
@@ -19,6 +19,14 @@
         <div class="form-group">
             <div class="checkbox">
                 <label>
+                    <input id="show_signed_up_only" type="checkbox">
+                    I am signed up for
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
                     <input id="is_trained" type="checkbox">
                     I am trained for
                 </label>
@@ -37,14 +45,6 @@
                 <label>
                     <input id="show_past" type="checkbox">
                     Show finished shifts
-                </label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="checkbox">
-                <label>
-                    <input id="show_signed_up_only" type="checkbox">
-                    I'm signed up for
                 </label>
             </div>
         </div>

--- a/templates/volunteer/role.html
+++ b/templates/volunteer/role.html
@@ -32,7 +32,11 @@
             <input id="csrf_token" name=_csrf_token type=hidden value="{{ csrf_token() }}">
 
             <button class="btn btn-primary debounce">
-                Sign up for this role
+                {% if signed_up_for_role %}
+                    I'm no longer interested in this role
+                {% else %}
+                    Sign up for this role
+                {% endif %}
             </button>
         </form>
     {% endif %}

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -60,6 +60,7 @@
         </div>
     </noscript>
 
+    <p>Listed below are 
     {% if untrained_roles %}
     <div class="alert alert-info">
     You still need training before starting a shift for the following roles:
@@ -171,7 +172,9 @@
         $('#tabnav-sat a').attr('href', '#sat');
         $('#tabnav-sun a').attr('href', '#sun');
         $('#tabnav-mon a').attr('href', '#mon');
+        $('#show_signed_up_only').attr('checked', true);
         $('#is_interested').attr('checked', true);
+        $('#hide_full').attr('checked', true);
 
         var volunteer_shifts = {{ all_shifts | tojson }},
             volunteer_roles = {{ roles | tojson }},


### PR DESCRIPTION
1. Fix an exception when trying to remove yourself from a role via the role details page.

2. Funnel people towards the shift schedule wherever possible.

3. Update the schedule view so that by default it shows only slots that the user is interested in, has signed up for, and are not full.